### PR TITLE
Fix build error in make with undefined reference to '__alloca'

### DIFF
--- a/package/make/build
+++ b/package/make/build
@@ -12,6 +12,10 @@ sed -i -e '1597 {
     q1
   }' job.c
 
+# Workaround for undefined reference to `__alloca'
+# http://gnu-make.2324884.n4.nabble.com/undefined-reference-to-alloca-tp18308.html
+sed -i -e 's/# if _GNU_GLOB_INTERFACE_VERSION == GLOB_INTERFACE_VERSION/# if _GNU_GLOB_INTERFACE_VERSION >= GLOB_INTERFACE_VERSION/' glob/glob.c
+
 ./configure --prefix="$out"
 sh build.sh
 ./make install


### PR DESCRIPTION
Without this patch, I get the following error:
```
/tmp/make.GnpgDCi9/make-3.81/./glob/glob.c:1361: undefined reference to `__alloca'
```

Full logs: https://gist.github.com/mikemintz/297785e8c3850147b15196b1e8cc1531

I'm not sure which information to provide to reproduce, but here is something:
```
$ uname -a
Linux prim 5.0.2-arch1-1-ARCH #1 SMP PREEMPT Thu Mar 14 18:47:49 UTC 2019 x86_64 GNU/Linux

$ gcc --version
gcc (GCC) 8.2.1 20181127
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```