### PR TITLE
Fail loudly if any source fails to download

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ How to use:
 
 1. Fetch package sources:
 
-    find package -name sources -execdir wget -nc -i {} \;
+    find package -name sources -print0 | xargs -0 -n1 sh -c 'wget -nc -i $0 || exit 255'
 
 2. Build:
 


### PR DESCRIPTION
Previously I failed to download mawk (https://github.com/stebulus/egg-linux/pull/5) but I didn't notice since the `find` command in the README looked like it finished successfully.

This change makes the `find` command exit after the first error, so it'll be obvious from the console output that it ended in a failure.